### PR TITLE
Improve redirect handling for WowAuctions

### DIFF
--- a/server/services/wowauctions.js
+++ b/server/services/wowauctions.js
@@ -11,7 +11,30 @@ async function fetchItem(realm, itemId) {
   }
   const url = `https://www.wowauctions.net/auctionHouse/turtle-wow/${realm}/mergedAh/${itemId}`;
   console.log(`Scraping WowAuctions URL: ${url}`);
-  const { data: html } = await axios.get(url);
+
+  // Some pages redirect to a slugged URL (e.g. .../item-name-<id>) which
+  // axios fails to follow correctly in this environment. Perform the first
+  // request with redirects disabled so we can manually follow the provided
+  // location header.
+  let html;
+  try {
+    const resp = await axios.get(url, {
+      maxRedirects: 0,
+      validateStatus: status => status >= 200 && status < 400
+    });
+    if (resp.status >= 300 && resp.headers.location) {
+      const next = resp.headers.location.startsWith('http')
+        ? resp.headers.location
+        : `https://www.wowauctions.net${resp.headers.location}`;
+      console.log(`Following redirect to ${next}`);
+      html = (await axios.get(next)).data;
+    } else {
+      html = resp.data;
+    }
+  } catch (err) {
+    console.error(`Request failed for ${itemId}:`, err.message);
+    throw err;
+  }
   const $ = cheerio.load(html);
   const avgPrice = parseFloat($('.average-price').text().replace(/\D/g, '')) || 0;
   const listings = $('.listing-row .price')


### PR DESCRIPTION
## Summary
- handle manual redirects when scraping WowAuctions

## Testing
- `node cli.js aux-addon.lua nordanaar` *(fails: Maximum number of redirects exceeded)*
- `node -e "require('https').get('https://www.wowauctions.net/auctionHouse/turtle-wow/nordanaar/mergedAh/19710',res=>console.log('status',res.statusCode)).on('error',e=>console.log('error',e.code));"`

------
https://chatgpt.com/codex/tasks/task_e_68691a1e286883259a058d00285fb204